### PR TITLE
stream: set connection monitor delay.

### DIFF
--- a/exchanges/stream/websocket.go
+++ b/exchanges/stream/websocket.go
@@ -115,7 +115,8 @@ func (w *Websocket) Setup(s *WebsocketSetup) error {
 	if w.features.Unsubscribe && s.Unsubscriber == nil {
 		return fmt.Errorf("%s %w", w.exchangeName, errWebsocketUnsubscriberUnset)
 	}
-	if s.ConnectionMonitorDelay <= 0 {
+	w.connectionMonitorDelay = s.ConnectionMonitorDelay
+	if w.connectionMonitorDelay <= 0 {
 		w.connectionMonitorDelay = defaultConnectionMonitorDelay
 	}
 	w.Unsubscriber = s.Unsubscriber


### PR DESCRIPTION
- this fixes a bug where the connection monitor delay config value does not get set to the websocket on intialization.